### PR TITLE
Better handling of plural

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Enter a package name::
     ----------------------------------------------
     Django has been downloaded 3,182,234 times!
 
-Or enter a package name with version specification:: 
+Or enter a package name with version specification::
 
     $ vanity pillow==2.0.0
                     Pillow-2.0.0.zip    2013-03-15       61,022
@@ -63,10 +63,10 @@ Or enter a package name with version specification::
 
 Or enter more than one package name::
 
-    $ bin/vanity --quiet setuptools distribute 
-    setuptools has been downloaded 9,181,047 times!
-    distribute has been downloaded 7,487,115 times!
-    setuptools, distribute has been downloaded 16,668,162 times!
+    $ bin/vanity --quiet setuptools distribute
+    setuptools has been downloaded 34,601,114 times!
+    distribute has been downloaded 29,661,287 times!
+    setuptools and distribute have been downloaded 64,262,401 times!
 
 Installation
 ------------
@@ -79,6 +79,6 @@ Or::
 
     $ easy_install vanity
 
-Or download the compressed archive, extract it, and inside it run:: 
+Or download the compressed archive, extract it, and inside it run::
 
     $ python setup.py install

--- a/vanity.py
+++ b/vanity.py
@@ -176,9 +176,12 @@ def vanity():
         grand_total += total
         package_list.append(package)
     if len(package_list) > 1:
+        # List packages like "a and b" or "a, b and c" or "a, b, c and d"
+        package_string = (', '.join(package_list[:-1]) + " and " +
+                          package_list[-1])
         print(
-            "%s has been downloaded %s times!" % (
-                ', '.join(package_list), locale.format(
+            "%s have been downloaded %s times!" % (
+                package_string, locale.format(
                     "%d", grand_total, grouping=True)))
 
 if __name__ == '__main__':


### PR DESCRIPTION
- "has" -> "have" for more than one
- add "and" to the package list, instead of "a, b, c" -> "a, b and c"

So instead of 

> "setuptools, distribute has been downloaded 16,668,162 times!"

print like

> "setuptools and distribute have been downloaded 16,668,162 times!"
