### PR TITLE
Latest Coverage no longer supports Py3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
 
 install:
   - python setup.py install
-  - travis_retry pip install coverage
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
   - coverage erase
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     description='Get package download statistics from PyPI',
     entry_points={


### PR DESCRIPTION
Python 3.2 builds failed:
https://travis-ci.org/hugovk/vanity/builds/100328395

That's because the latest Coverage no longer supports Python 3.2, so stick that one to the last supported version.

It passes:
https://travis-ci.org/hugovk/vanity/builds/100332351

I also added Python 3.5 (it passes).

---

Please can you also enable Travis CI for your aclark4life/vanity repo?
Enable it here: https://travis-ci.org/profile
