### PR TITLE
Add --pattern option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - coverage run --append --include=./* vanity.py pil
   - coverage run --append --include=./* vanity.py vanity==0.0.0
   - coverage run --append --include=./* vanity.py vanity==1.0
-  - coverage run --append --include=./* vanity pillow --pattern "Pillow-3.0.0.*win32.*py3.2|Pillow-3.0.0.*cp32.*win32"
+  - coverage run --append --include=./* vanity.py pillow --pattern "Pillow-3.0.0.*win32.*py3.2|Pillow-3.0.0.*cp32.*win32"
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - coverage run --append --include=./* vanity.py pil
   - coverage run --append --include=./* vanity.py vanity==0.0.0
   - coverage run --append --include=./* vanity.py vanity==1.0
+  - coverage run --append --include=./* vanity pillow --pattern "Pillow-3.0.0.*win32.*py3.2|Pillow-3.0.0.*cp32.*win32"
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
 
 install:
   - python setup.py install
-  - travis_retry pip install coverage
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
   - coverage erase
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     description='Get package download statistics from PyPI',
     entry_points={

--- a/vanity.py
+++ b/vanity.py
@@ -38,6 +38,7 @@ import argparse
 import json
 import locale
 import logging
+import re
 import time
 
 # PyPI's XML-RPC methods
@@ -94,7 +95,8 @@ def by_two(source):
             out = []
 
 
-def count_downloads(package, verbose=True, version=None, json=False):
+def count_downloads(package, verbose=True, version=None, json=False,
+                    pattern=None):
     """
     """
     count = 0
@@ -102,6 +104,8 @@ def count_downloads(package, verbose=True, version=None, json=False):
     for urls, data in get_release_info([package], json=json):
         for url in urls:
             filename = url['filename']
+            if pattern and not re.search(pattern, filename):
+                continue
             downloads = url['downloads']
             downloads = locale.format("%d", downloads, grouping=True)
             if not json:
@@ -209,6 +213,10 @@ def vanity():
         '-j',
         '--json',
         help='use pypi json api instead of xmlrpc', action='store_true')
+    parser.add_argument(
+        '-p',
+        '--pattern',
+        help='only show files matching a regex pattern')
     args = parser.parse_args()
     packages = args.package
     verbose = not(args.quiet)
@@ -229,8 +237,8 @@ def vanity():
             package,
             json=json,
             version=version,
-            verbose=verbose)
-
+            verbose=verbose,
+            pattern=args.pattern)
         if total != 0:
             if version:
                 logger.debug(


### PR DESCRIPTION
Add a `--pattern` option to filter the results using a regex. 

So for example you can just see the Pillow downloads for Python 3.2:

```
C:\>vanity pillow -p "Pillow-3.0.0.*win32.*py3.2|Pillow-3.0.0.*cp32.*win32"
    Pillow-3.0.0.win32-py3.2.exe    2015-10-01          582
Pillow-3.0.0-cp32-none-win32.whl    2015-10-01          591
-----------------------------------------------------------
Pillow has been downloaded 1173 times!
```

---

Also includes PR https://github.com/aclark4life/vanity/pull/20.

