### PR TITLE
Fixed #16 by sorting the json dict keys

### DIFF
--- a/vanity.py
+++ b/vanity.py
@@ -21,7 +21,7 @@ Get package download statistics from PyPI
 
 # For sorting XML-RPC results
 
-from collections import deque
+from collections import deque, OrderedDict
 
 # HTTPS connection for normalize function
 
@@ -133,7 +133,12 @@ def get_jsonparsed_data(url):
     """Receive the content of ``url``, parse it as JSON and return the
        object.
     """
-    return requests.get(url).json()
+    response = requests.get(url).json()
+    sorted_releases = OrderedDict()
+    for release in sorted(response['releases'].keys())[::-1]:
+        sorted_releases[release] = response['releases'][release]
+    response['releases'] = sorted_releases
+    return response
 
 
 def normalize(name):


### PR DESCRIPTION
Fixed the sorting issue when using json.

Before fix:

```
$ python vanity.py -j vanity
     vanity-1.0.zip    2011-04-14        2,628
   vanity-1.1.0.zip    2011-10-26        2,416
   vanity-1.1.2.zip    2011-10-28        2,417
   vanity-2.2.1.zip    2016-04-27           30
vanity-2.2.1.tar.gz    2016-04-27           90
   vanity-2.0.4.zip    2014-09-03        1,221
   vanity-2.0.0.zip    2013-05-26        1,651
   vanity-2.0.1.zip    2013-05-27        1,660
   vanity-2.0.5.zip    2014-09-03        2,958
   vanity-2.0.2.zip    2013-05-27        1,671
   vanity-1.2.5.zip    2013-03-18        1,909
   vanity-1.2.3.zip    2012-08-08        2,186
   vanity-1.2.2.zip    2012-07-31        2,133
   vanity-2.0.3.zip    2013-06-28        2,645
   vanity-2.2.0.zip    2016-01-06          253
vanity-2.2.0.tar.gz    2016-01-06          399
vanity-1.2.1.tar.gz    2012-02-16        2,473
   vanity-2.1.0.zip    2015-07-03        3,395
   vanity-2.2.2.zip    2016-08-21            0
vanity-2.2.2.tar.gz    2016-08-21            0
   vanity-1.2.4.zip    2013-02-19        1,897
   vanity-1.1.1.zip    2011-10-28        2,546
vanity-1.2.0.tar.gz    2012-01-30        2,362
----------------------------------------------
vanity has been downloaded 38,940 times!
```

After fix:

```
$ python vanity.py -j vanity
     vanity-1.0.zip    2011-04-14        2,628
   vanity-1.1.0.zip    2011-10-26        2,416
   vanity-1.1.1.zip    2011-10-28        2,546
   vanity-1.1.2.zip    2011-10-28        2,417
vanity-1.2.0.tar.gz    2012-01-30        2,362
vanity-1.2.1.tar.gz    2012-02-16        2,473
   vanity-1.2.2.zip    2012-07-31        2,133
   vanity-1.2.3.zip    2012-08-08        2,186
   vanity-1.2.4.zip    2013-02-19        1,897
   vanity-1.2.5.zip    2013-03-18        1,909
   vanity-2.0.0.zip    2013-05-26        1,651
   vanity-2.0.1.zip    2013-05-27        1,660
   vanity-2.0.2.zip    2013-05-27        1,671
   vanity-2.0.3.zip    2013-06-28        2,645
   vanity-2.0.4.zip    2014-09-03        1,221
   vanity-2.0.5.zip    2014-09-03        2,958
   vanity-2.1.0.zip    2015-07-03        3,395
   vanity-2.2.0.zip    2016-01-06          253
vanity-2.2.0.tar.gz    2016-01-06          399
   vanity-2.2.1.zip    2016-04-27           30
vanity-2.2.1.tar.gz    2016-04-27           90
   vanity-2.2.2.zip    2016-08-21            0
vanity-2.2.2.tar.gz    2016-08-21            0
----------------------------------------------
vanity has been downloaded 38,940 times!
```

The solution was to use an OrderedDict to maintain sorted releases as soon as we get the data.