### PR TITLE
Update requests to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.11.0
+requests==2.11.1
 -e .


### PR DESCRIPTION
```
C:\Users\hugovk>vanity vanity
Traceback (most recent call last):
  File "C:\Python27\Scripts\vanity-script.py", line 5, in <module>
    from pkg_resources import load_entry_point
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 3084, in <module>
    @_call_aside
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 3070, in _call_aside
    f(*args, **kwargs)
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 3097, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 653, in _build_master
    return cls._build_from_requirements(__requires__)
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 666, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 839, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'requests==2.11.0' distribution was not found and is required by vanity

C:\Users\hugovk>pip freeze | grep requests
requests==2.11.1

C:\Users\hugovk>pip install -U requests
Requirement already up-to-date: requests in c:\python27\lib\site-packages
```

Could it be unpinned, to avoid needing to update the version number for each requests release?
