### PR TITLE
Add Empty String check in Normalize

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,7 @@ import unittest
 import vanity
 
 
-class test_normalize(unittest.TestCase):
+class TestNormalize(unittest.TestCase):
     """
     A test class for the normalize method.
     """
@@ -33,11 +33,6 @@ class test_normalize(unittest.TestCase):
         self.assertEqual(normalized, "               Flask                ")
 
     def test_empty(self):
-        """
-        TODO: this test is rather slow to run,
-        perhaps normalize could be refactored to check this
-        and kick out faster.
-        """
         normalized = vanity.normalize("")
         self.assertEqual(normalized, "")
 

--- a/vanity.py
+++ b/vanity.py
@@ -173,6 +173,9 @@ def normalize(name):
     @r_param normalized_name: Verified package name
     @r_type normalized_name: str
     """
+    if name == "":
+        return ""
+
     http = HTTPSConnection(PYPI_HOST)
     http.request('HEAD', '/pypi/%s/' % name)
     r = http.getresponse()


### PR DESCRIPTION
Return "" if name is empty at start of normalize method, rather than search PyPI for it.

Also, remove TODO from tests and correct test class name.