### PR TITLE
Add tests for count_downloads

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,108 @@
 import unittest
+import mock
+import datetime
 
 import vanity
+
+
+# mocks
+def empty_release_info(package, json):
+    return iter(())
+
+
+def single_release_info(package, json):
+    url = {'filename': 'fake package',
+           'downloads': 1,
+           'upload_time': datetime.date(2016, 10, 13)}
+    data = {'version': '1.0'}
+
+    yield [url], data
+
+
+def two_url_release_info(package, json):
+    first_url = {'filename': 'fake package',
+                 'downloads': 1,
+                 'upload_time': datetime.date(2016, 10, 13)}
+
+    second_url = {'filename': 'fake package two',
+                  'downloads': 2,
+                  'upload_time': datetime.date(2016, 10, 13)}
+
+    data = {'version': '1.0'}
+
+    yield [first_url, second_url], data
+
+
+# http://stackoverflow.com/q/21611559
+def Any(type):
+    class Any(type):
+        def __eq__(self, other):
+            return True
+    return Any()
+
+
+class TestCountDownloads(unittest.TestCase):
+    """
+    A test class for the count_downloads method.
+    """
+
+    @mock.patch('vanity.get_release_info', side_effect=empty_release_info)
+    def test_count_empty(self, get_release_func):
+        count = vanity.count_downloads(None)
+
+        self.assertEqual(count, 0)
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_count_single(self, get_release_func):
+        count = vanity.count_downloads('fake package')
+
+        self.assertEqual(count, 1)
+
+    @mock.patch('vanity.get_release_info', side_effect=two_url_release_info)
+    def test_count_multiple(self, get_release_func):
+        count = vanity.count_downloads('fake package')
+
+        self.assertEqual(count, 3)
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_count_version(self, get_release_func):
+        count = vanity.count_downloads('fake package',
+                                       version='1.1')
+
+        self.assertEqual(count, 0)
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_bad_pattern(self, get_release_func):
+        count = vanity.count_downloads('fake package',
+                                       pattern='real')
+
+        self.assertEqual(count, 0)
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_good_pattern(self, get_release_func):
+        count = vanity.count_downloads('fake package',
+                                       pattern='[Ff]ake')
+
+        self.assertEqual(count, 1)
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_verbose_calls_debug(self, get_release_func):
+        mock_logger = mock.Mock()
+        vanity.logger = mock_logger
+
+        count = vanity.count_downloads('fake package')
+
+        mock_logger.debug.assert_any_call(Any(str))
+
+    @mock.patch('vanity.get_release_info', side_effect=single_release_info)
+    def test_not_verbose_no_debug(self, get_release_func):
+        mock_logger = mock.Mock()
+        vanity.logger = mock_logger
+
+        count = vanity.count_downloads('fake package',
+                                       verbose=False)
+
+        mock_logger.debug.assert_not_called()
 
 
 class TestByTwo(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -34,8 +34,8 @@ def two_url_release_info(package, json):
 
 
 # http://stackoverflow.com/q/21611559
-def Any(type):
-    class Any(type):
+def Any(object_type):
+    class Any(object_type):
         def __eq__(self, other):
             return True
     return Any()
@@ -92,6 +92,7 @@ class TestCountDownloads(unittest.TestCase):
 
         count = vanity.count_downloads('fake package')
 
+        self.assertEqual(count, 1)
         mock_logger.debug.assert_any_call(Any(str))
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
@@ -102,6 +103,7 @@ class TestCountDownloads(unittest.TestCase):
         count = vanity.count_downloads('fake package',
                                        verbose=False)
 
+        self.assertEqual(count, 1)
         mock_logger.debug.assert_not_called()
 
 


### PR DESCRIPTION
Makes use of mocked get_release_info method to test basic counting, pattern matching, and verbose flags.