### PR TITLE
Add tests for get_jsonparsed_data method

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,14 @@ import vanity
 
 
 # mocks
+def mock_single_release(url):
+    return {'releases': {'1.0': ''}}
+
+
+def mock_multi_release(url):
+    return {'releases': {'2.0': '1', '1.0': 'a', '3.1': 'a', '1.5': ''}}
+
+
 def empty_release_info(package, json):
     return iter(())
 
@@ -39,6 +47,38 @@ def Any(object_type):
         def __eq__(self, other):
             return True
     return Any()
+
+    
+class TestGetJsonParsedData(unittest.TestCase):
+    """
+    A test class for the get_jsonparsed_data method.
+    """
+
+    def test_none(self):
+        self.assertRaises(AttributeError,
+                          vanity.get_jsonparsed_data,
+                          None)
+
+    def test_empty_string(self):
+        self.assertRaises(ValueError,
+                          vanity.get_jsonparsed_data,
+                          '')
+
+    @mock.patch('vanity.get_json_from_url', side_effect=mock_single_release)
+    def test_single_release(self, mock_json_func):
+        expected = {'1.0': ''}
+        response = vanity.get_jsonparsed_data('fake url')
+
+        mock_json_func.assert_called_with('fake url')
+        self.assertEqual(response['releases'], expected)
+
+    @mock.patch('vanity.get_json_from_url', side_effect=mock_multi_release)
+    def test_multi_release_sorts(self, mock_json_func):
+        expected = {'1.0': 'a', '1.5': '', '2.0': '1', '3.1': 'a'}
+        response = vanity.get_jsonparsed_data('fake url')
+
+        mock_json_func.assert_called_with('fake url')
+        self.assertEqual(response['releases'], expected)
 
 
 class TestCountDownloads(unittest.TestCase):

--- a/vanity.py
+++ b/vanity.py
@@ -141,6 +141,13 @@ def count_downloads(package,
     return count
 
 
+def get_json_from_url(url):
+    """
+    Returns content of url as json
+    """
+    response = urlopen(url)
+    return json.loads(response.read().decode('utf-8'))
+
 # http://stackoverflow.com/a/28786650
 def get_jsonparsed_data(url):
     """Receive content of 'url', parse it as JSON, return the object.
@@ -150,8 +157,7 @@ def get_jsonparsed_data(url):
     @r_param response: JSON data from the URL
     @r_type response: dict
     """
-    response = urlopen(url)
-    response = json.loads(response.read().decode('utf-8'))
+    response = get_json_from_url(url)
 
     sorted_releases = OrderedDict()
     for release in sorted(response['releases'].keys())[::-1]:


### PR DESCRIPTION
Tests: None, empty string, and sorting/results for single, and multiple releases.

Refactored get_jsonparsed_data to separate the reading of url to allow mocking json result. This separation will allow higher level integration tests to run.

For example, call "count_downloads" with json=True, and have a test use the actual get_release_info and get_jsonparsed_data, but mocked get_json_from_url.