### PR TITLE
Integration Tests on vanity method

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,21 @@ def mock_multi_release(url):
     return {'releases': {'2.0': '1', '1.0': 'a', '3.1': 'a', '1.5': ''}}
 
 
+def mock_json_data(url):
+    return {'releases':
+            {'1.0': [{'filename': 'fake package',
+                      'downloads': 1,
+                      'upload_time': '2016-10-12T03:00:42'}],
+             '1.9': [{'filename': 'fake package',
+                      'downloads': 3,
+                      'upload_time': '2016-10-13T09:01:00'}],
+             '1.2': [{'filename': 'fake package',
+                      'downloads': 2,
+                      'upload_time': '2016-10-13T02:10:08'}]
+             },
+            'info': {'version': '1.0'}}
+
+
 def empty_release_info(package, json):
     return iter(())
 
@@ -48,7 +63,7 @@ def Any(object_type):
             return True
     return Any()
 
-    
+
 class TestGetJsonParsedData(unittest.TestCase):
     """
     A test class for the get_jsonparsed_data method.
@@ -103,6 +118,15 @@ class TestCountDownloads(unittest.TestCase):
         count = vanity.count_downloads('fake package')
 
         self.assertEqual(count, 3)
+
+    @mock.patch('vanity.get_json_from_url', side_effect=mock_json_data)
+    def test_count_json(self, get_json_func):
+        expected_url = 'https://pypi.python.org/pypi/fake package/json'
+        count = vanity.count_downloads('fake package',
+                                       json=True)
+
+        get_json_func.assert_called_with(expected_url)
+        self.assertEqual(count, 6)
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_count_version(self, get_release_func):

--- a/tests.py
+++ b/tests.py
@@ -16,13 +16,13 @@ def mock_multi_release(url):
 
 def mock_json_data(url):
     return {'releases':
-            {'1.0': [{'filename': 'fake package',
+            {'1.0': [{'filename': 'fake-package',
                       'downloads': 1,
                       'upload_time': '2016-10-12T03:00:42'}],
-             '1.9': [{'filename': 'fake package',
+             '1.9': [{'filename': 'fake-package',
                       'downloads': 3,
                       'upload_time': '2016-10-13T09:01:00'}],
-             '1.2': [{'filename': 'fake package',
+             '1.2': [{'filename': 'fake-package',
                       'downloads': 2,
                       'upload_time': '2016-10-13T02:10:08'}]
              },
@@ -34,7 +34,7 @@ def empty_release_info(package, json):
 
 
 def single_release_info(package, json):
-    url = {'filename': 'fake package',
+    url = {'filename': 'fake-package',
            'downloads': 1,
            'upload_time': datetime.date(2016, 10, 13)}
     data = {'version': '1.0'}
@@ -43,11 +43,11 @@ def single_release_info(package, json):
 
 
 def two_url_release_info(package, json):
-    first_url = {'filename': 'fake package',
+    first_url = {'filename': 'fake-package',
                  'downloads': 1,
                  'upload_time': datetime.date(2016, 10, 13)}
 
-    second_url = {'filename': 'fake package two',
+    second_url = {'filename': 'fake-package two',
                   'downloads': 2,
                   'upload_time': datetime.date(2016, 10, 13)}
 
@@ -122,20 +122,20 @@ class TestCountDownloads(unittest.TestCase):
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_count_single(self, get_release_func):
-        count = vanity.count_downloads('fake package')
+        count = vanity.count_downloads('fake-package')
 
         self.assertEqual(count, 1)
 
     @mock.patch('vanity.get_release_info', side_effect=two_url_release_info)
     def test_count_multiple(self, get_release_func):
-        count = vanity.count_downloads('fake package')
+        count = vanity.count_downloads('fake-package')
 
         self.assertEqual(count, 3)
 
     @mock.patch('vanity.get_json_from_url', side_effect=mock_json_data)
     def test_count_json(self, get_json_func):
-        expected_url = 'https://pypi.python.org/pypi/fake package/json'
-        count = vanity.count_downloads('fake package',
+        expected_url = 'https://pypi.python.org/pypi/fake-package/json'
+        count = vanity.count_downloads('fake-package',
                                        json=True)
 
         get_json_func.assert_called_with(expected_url)
@@ -143,21 +143,21 @@ class TestCountDownloads(unittest.TestCase):
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_count_version(self, get_release_func):
-        count = vanity.count_downloads('fake package',
+        count = vanity.count_downloads('fake-package',
                                        version='1.1')
 
         self.assertEqual(count, 0)
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_bad_pattern(self, get_release_func):
-        count = vanity.count_downloads('fake package',
+        count = vanity.count_downloads('fake-package',
                                        pattern='real')
 
         self.assertEqual(count, 0)
 
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_good_pattern(self, get_release_func):
-        count = vanity.count_downloads('fake package',
+        count = vanity.count_downloads('fake-package',
                                        pattern='[Ff]ake')
 
         self.assertEqual(count, 1)
@@ -165,7 +165,7 @@ class TestCountDownloads(unittest.TestCase):
     @mock.patch('vanity.get_release_info', side_effect=single_release_info)
     def test_verbose_calls_debug(self, get_release_func):
 
-        count = vanity.count_downloads('fake package')
+        count = vanity.count_downloads('fake-package')
 
         self.assertEqual(count, 1)
         self.mock_logger.debug.assert_any_call(Any(str))
@@ -174,7 +174,7 @@ class TestCountDownloads(unittest.TestCase):
     def test_not_verbose_no_debug(self, get_release_func):
         self.mock_logger = mock.Mock()
 
-        count = vanity.count_downloads('fake package',
+        count = vanity.count_downloads('fake-package',
                                        verbose=False)
 
         self.assertEqual(count, 1)
@@ -268,37 +268,36 @@ class TestVanity(unittest.TestCase):
     @mock.patch('vanity.get_json_from_url', side_effect=mock_json_data)
     def test_vanity_count_downloads(self, mock_json_func, mock_norm_func):
         # NB: mocks are passed in reverse order
-        expected_url = 'https://pypi.python.org/pypi/fake package/json'
+        expected_url = 'https://pypi.python.org/pypi/fake-package/json'
 
-        vanity.vanity(packages=['fake package'],
+        vanity.vanity(packages=['fake-package'],
                       verbose=True,
                       json=True,
                       pattern=None)
 
-        mock_norm_func.assert_called_with('fake package')
+        mock_norm_func.assert_called_with('fake-package')
         mock_json_func.assert_called_with(expected_url)
         self.mock_logger.debug.assert_any_call(
             '%s has been downloaded %s times!',
-            'fake package',
+            'fake-package',
             '6')
 
     @mock.patch('vanity.normalize', side_effect=mock_normalize)
     @mock.patch('vanity.get_json_from_url', side_effect=mock_json_data)
     def test_vanity_version_downloads(self, mock_json_func, mock_norm_func):
         # NB: mocks are passed in reverse order
-        expected_url = 'https://pypi.python.org/pypi/fake package/json'
+        expected_url = 'https://pypi.python.org/pypi/fake-package/json'
 
-        vanity.vanity(packages=['fake package==1.0'],
+        vanity.vanity(packages=['fake-package==1.0'],
                       verbose=True,
                       json=True,
                       pattern=None)
 
-        mock_norm_func.assert_called_with('fake package')
+        mock_norm_func.assert_called_with('fake-package')
         mock_json_func.assert_called_with(expected_url)
-        print(self.mock_logger.mock_calls)
         self.mock_logger.debug.assert_any_call(
             '%s %s has been downloaded %s times!',
-            'fake package',
+            'fake-package',
             '1.0',
             '6')
 

--- a/vanity.py
+++ b/vanity.py
@@ -258,7 +258,7 @@ def get_release_info(packages, json=False):
         yield urls, data
 
 
-def vanity(packages, verbose, json):
+def vanity(packages, verbose, json, pattern):
     """Parse args, verify package, retrieve details, return download count."""
     version = None
     grand_total = 0
@@ -277,7 +277,7 @@ def vanity(packages, verbose, json):
                                 json=json,
                                 version=version,
                                 verbose=verbose,
-                                pattern=args.pattern)
+                                pattern=pattern)
         if total != 0:
             if version:
                 logger.debug('%s %s has been downloaded %s times!',
@@ -326,4 +326,5 @@ if __name__ == '__main__':
 
     vanity(packages=args.package,
            verbose=not (args.quiet),
-           json=args.json)
+           json=args.json,
+           pattern=args.pattern)

--- a/vanity.py
+++ b/vanity.py
@@ -94,9 +94,9 @@ def count_downloads(package,
                     pattern=None):
     """Receive package details, retrieve and return download count.
 
-    Call get_release_info() method to make requests to get package details, check for verbose and
-    json toggles, debug for discrepancies, maintain a download count counter,
-    and return total number of downloads.
+    Call get_release_info() method to make requests to get package details,
+    check for verbose and json toggles, debug for discrepancies,
+    maintain a download count counter and return total number of downloads.
 
     @param package: Name of package to be retrieved.
     @type package: str
@@ -147,6 +147,7 @@ def get_json_from_url(url):
     """
     response = urlopen(url)
     return json.loads(response.read().decode('utf-8'))
+
 
 # http://stackoverflow.com/a/28786650
 def get_jsonparsed_data(url):
@@ -257,28 +258,11 @@ def get_release_info(packages, json=False):
         yield urls, data
 
 
-def vanity():
+def vanity(packages, verbose, json):
     """Parse args, verify package, retrieve details, return download count."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('package', help='pypi package name', nargs='+')
-    parser.add_argument('-q',
-                        '--quiet',
-                        help='only show total downloads',
-                        action='store_true')
-    parser.add_argument('-j',
-                        '--json',
-                        help='use pypi json api instead of xmlrpc',
-                        action='store_true')
-    parser.add_argument('-p',
-                        '--pattern',
-                        help='only show files matching a regex pattern')
-    args = parser.parse_args()
-    packages = args.package
-    verbose = not (args.quiet)
     version = None
     grand_total = 0
     package_list = []
-    json = args.json
     for package in packages:
         if package.find('==') >= 0:
             package, version = package.split('==')
@@ -296,15 +280,15 @@ def vanity():
                                 pattern=args.pattern)
         if total != 0:
             if version:
-                logger.debug('%s %s has been downloaded %s times!', 
+                logger.debug('%s %s has been downloaded %s times!',
                              package, version, locale.format("%d",
-                                                              total,
-                                                              grouping=True))
+                                                             total,
+                                                             grouping=True))
             else:
                 logger.debug('%s has been downloaded %s times!',
                              package, locale.format("%d",
-                                                     total,
-                                                     grouping=True))
+                                                    total,
+                                                    grouping=True))
         else:
             if version:
                 logger.debug('No downloads for %s %s.', package, version)
@@ -315,14 +299,31 @@ def vanity():
     if len(package_list) > 1:
         package_string = (
             ', '.join(package_list[:-1]) + " and " + package_list[-1])
-        logger.debug("%s have been downloaded %s times!", 
+        logger.debug("%s have been downloaded %s times!",
                      package_string, locale.format("%d",
-                                                    grand_total,
-                                                    grouping=True))
+                                                   grand_total,
+                                                   grouping=True))
 
     logger.debug("\n\n\t *** Note: PyPI stats are broken again; we're now"
                  "waiting for warehouse. https://github.com/aclark4life/"
                  "vanity/issues/22 ***\n\n")
 
 if __name__ == '__main__':
-    vanity()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('package', help='pypi package name', nargs='+')
+    parser.add_argument('-q',
+                        '--quiet',
+                        help='only show total downloads',
+                        action='store_true')
+    parser.add_argument('-j',
+                        '--json',
+                        help='use pypi json api instead of xmlrpc',
+                        action='store_true')
+    parser.add_argument('-p',
+                        '--pattern',
+                        help='only show files matching a regex pattern')
+    args = parser.parse_args()
+
+    vanity(packages=args.package,
+           verbose=not (args.quiet),
+           json=args.json)


### PR DESCRIPTION
Refactor the command line args out of vanity method and added as parameters (to allow for testing).

Add some basic integration tests on vanity method.

Clean up mocks in tests.py (use setUp/tearDown for logger mock)

Misc pep8 cleanup