### PR TITLE
Upgrade pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - pypy
-  - pypy3
+  - pypy3.3-5.5-alpha
   - 2.7
   - 2.7_with_system_site_packages
   - 3.3


### PR DESCRIPTION
The PyPy3 installed with `pypy3` is an old Python 3.2 and pip no longer supports it, breaking the build:
```
pip 8.1.2 from /home/travis/virtualenv/pypy3-2.4.0/site-packages (python 3.2)
0.38s$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 1, in <module>
    from setuptools import setup
  File "/home/travis/virtualenv/pypy3-2.4.0/site-packages/setuptools/__init__.py", line 12, in <module>
    import setuptools.version
  File "/home/travis/virtualenv/pypy3-2.4.0/site-packages/setuptools/version.py", line 1, in <module>
    import pkg_resources
  File "/home/travis/virtualenv/pypy3-2.4.0/site-packages/pkg_resources/__init__.py", line 77, in <module>
    raise RuntimeError("Python 3.3 or later is required")
RuntimeError: Python 3.3 or later is required
```
https://travis-ci.org/aclark4life/vanity/jobs/249531056#L119

So explicitly use a later version.
